### PR TITLE
fix: separate STC and Brent into independent scrape workflows

### DIFF
--- a/.github/workflows/scrape-brent.yml
+++ b/.github/workflows/scrape-brent.yml
@@ -1,13 +1,15 @@
-name: Scrape STC fuel prices
+name: Scrape Brent crude prices
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+    # Run on the 1st and 15th of each month — Brent data updates monthly
+    - cron: "0 6 1,15 * *"
 
 jobs:
   scrape:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -17,8 +19,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Fetch latest fuel prices
-        run: node fetch.mjs
+      - name: Fetch latest Brent crude prices
+        run: node fetch-brent.mjs
 
       - name: Commit and push if changed
         run: |
@@ -26,5 +28,5 @@ jobs:
           git config user.email "actions@users.noreply.github.com"
           git add -A
           timestamp=$(date -u)
-          git commit -m "Latest STC data: ${timestamp}" || exit 0
+          git commit -m "Latest Brent data: ${timestamp}" || exit 0
           git push

--- a/fetch-brent.mjs
+++ b/fetch-brent.mjs
@@ -20,12 +20,29 @@ function parseCSV(csv) {
     .filter(Boolean)
 }
 
+async function fetchWithRetry(url, { retries = 2, timeout = 30_000 } = {}) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(timeout) })
+      if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+      return response
+    }
+    catch (err) {
+      if (attempt < retries) {
+        console.log(`Attempt ${attempt + 1} failed: ${err.message}. Retrying in 5s...`)
+        await new Promise(r => setTimeout(r, 5_000))
+      } else {
+        throw err
+      }
+    }
+  }
+}
+
 async function main() {
   const fs = await import('fs')
 
   console.log('Fetching Brent crude monthly prices from FRED...')
-  const response = await fetch(FRED_CSV_URL)
-  if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`)
+  const response = await fetchWithRetry(FRED_CSV_URL)
   const csv = await response.text()
 
   const prices = parseCSV(csv)


### PR DESCRIPTION
## Problem

The [first CI run](https://github.com/MrSunshyne/mauritius-dataset-fuel/actions/runs/23508057493/job/68421283797) after merging brent support failed because the FRED CSV endpoint timed out (`ETIMEDOUT` after ~73s). Since both fetches were in the same job, the STC price commit — which had already succeeded — was blocked from being pushed.

## Fix

### Separate workflows
- **`scrape.yml`** — STC fuel prices only, daily at midnight UTC
- **`scrape-brent.yml`** — Brent crude only, 1st and 15th of each month at 06:00 UTC (brent data is monthly, daily is overkill)

Both support `workflow_dispatch` for manual triggering.

### Retry + timeout for FRED
- 30-second `AbortSignal.timeout` per attempt (instead of hanging for 73s)
- 2 retries with 5-second backoff before giving up